### PR TITLE
Fixed package.json for use github package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "git://github.com/mcychan/PnnQuant.js.git"
   },
   "keywords": [
-	"ciede2000",
+    "ciede2000",
     "color-quantization",
-	"error-diffusion",
+    "error-diffusion",
     "dithering",
     "image-processing"
-  ],
+  ]
 }


### PR DESCRIPTION
This miniscule fix allows it to be used by npm install via git (and later npm) and prevent npm install from failing over a syntax error (the trailing comma after the keywords array).

Also allows npm install to be used over the github link!